### PR TITLE
Do not change permissions if already mounted

### DIFF
--- a/recipes/mount.rb
+++ b/recipes/mount.rb
@@ -33,6 +33,7 @@ volumes(node).each do |vol_name, vol|
     owner       vol.owner
     group       vol.owner
     action      :nothing
+    not_if{ vol.mounted? }
   end
 
   #


### PR DESCRIPTION
Does not run the directory creation (for the mountpoint) if already mounted. This prevents changing of the permissions of the mounted '/.' 
