### PR TITLE
Added ability to force format to fstype

### DIFF
--- a/libraries/simple_volume.rb
+++ b/libraries/simple_volume.rb
@@ -22,7 +22,7 @@ module Metachef
     def inspect
       str = [super()[2..-2]]
       str << "ohai_fstype:#{current[:fstype]}"
-      "<#{self.class} #{str.join(" ")} #{current} a?#{attached?} m?#{mounted?} f?#{formattable?} r?#{resizable?}>"
+      "<#{self.class} #{str.join(" ")} #{current} a?#{attached?} m?#{mounted?} f?#{formattable?} r?#{resizable?} e?#{empty_device?}>"
     end
 
     # if device_type is :device, checks that the device is present.
@@ -54,7 +54,15 @@ module Metachef
     end
 
     def ready_to_format?
-      !!( formattable? && attached? && (not mounted?) && (`file -s #{device}`.chomp =~ /: data/) )
+      !!( formattable? && attached? && (not mounted?) && (empty_device? or force_fstype?) )
+    end
+
+    def empty_device?
+      !!(`file -s #{device}`.chomp =~ /: data/)
+    end
+
+    def force_fstype?
+      self['force_fstype'].to_s == 'true' and current['fstype'] != fstype
     end
 
     def in_raid?

--- a/recipes/format.rb
+++ b/recipes/format.rb
@@ -27,7 +27,7 @@ volumes(node).each do |vol_name, vol|
   Chef::Log.info(vol.inspect)
   next unless vol.formattable?
 
-  if not vol.ready_to_format? then Chef::Log.info("Skipping format of volume #{vol_name}: not formattable (#{vol.inspect})") ; next ; end
+  if not vol.ready_to_format? then Chef::Log.info("Skipping format of volume #{vol_name}: not ready to format (#{vol.inspect})") ; next ; end
 
   f = bash "Format #{vol_name} as #{vol.fstype}" do
     code        "mkfs -t #{vol.fstype} #{vol.device}"


### PR DESCRIPTION
Set `force_fstype=true` in attributes if target device should only be `fstype`. Will format device if empty or incorrect fstype