### PR TITLE
Reload ohai after mounting

### DIFF
--- a/recipes/mount.rb
+++ b/recipes/mount.rb
@@ -59,3 +59,8 @@ volumes(node).each do |vol_name, vol|
   vol_mount_rsrc.run_action(:mount)
 
 end
+
+ohai 'reload mountpoint' do
+  plugin 'filesystem'
+  action :nothing
+end.run_action(:reload)


### PR DESCRIPTION
After mounting filesystems ohai needs to be updated to be useful for other parts of chef. This is specifically needed for xfs when calling volumes::resize due to the filesystem needing to be mounted.